### PR TITLE
Fix broken image links by specifying the full path rather than relative path.

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 title: Apps
 ---
 
-[![Anywhere ABC app icon](/assets/Anywhere-ABC-app-icon.png)](/01-anywhere-abc.md)
+[![Anywhere ABC app icon](/assets/Anywhere-ABC-app-icon.png)](https://lorin-vr.github.io/Anywhere-ABC-info/01-anywhere-abc.html)
 
 Anywhere ABC is a flashcard app for learning alphabet letters, beginner words and sight words.
 
@@ -10,7 +10,7 @@ Anywhere ABC is a flashcard app for learning alphabet letters, beginner words an
 
 <br>
 
-[![Sprinkle Words app icon](/assets/Sprinkle-Words-app-icon.png)](/02-sprinkle-words.md)
+[![Sprinkle Words app icon](/assets/Sprinkle-Words-app-icon.png)](https://lorin-vr.github.io/Anywhere-ABC-info/02-sprinkle-words.html)
 
 Sprinkle Words is a classic word search puzzle for players of all ages.
 


### PR DESCRIPTION
It's not clear why the relative paths don't work for image links, as they certainly work for text links, but this should fix the problem.